### PR TITLE
Fixed non-existing commit hash in deps (oinksoft/reloader)

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
                 {tag, "0.8.2"}}},
   {rebar_feature_runner, ".*", {git, "https://github.com/madtrick/rebar_feature_runner",
                                 "bcbf1ba"}},
-  {reloader, ".", {git, "https://github.com/oinksoft/reloader.git", "36b5a55"}},
+  {reloader, ".", {git, "https://github.com/oinksoft/reloader.git", "1c981b9"}},
   {wsock, ".*", {git, "https://github.com/madtrick/wsock", {tag, "1.1.5"}}}
 ]}.
 


### PR DESCRIPTION
It seems that oinksoft/reloader is reorganized and that is why travis builds and tests of MongooseIM are failing.
